### PR TITLE
Awake 메시지 기능 추가, 참가중인 채팅방 조회 쿼리 버그 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-gson:0.11.2'
 
     // Jackson
-    // implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
-
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1'
 }
 
 //def querydslGeneratedDir = "$buildDir/generated/querydsl" as Object

--- a/src/main/java/com/cocotalk/chat/controller/ChatController.java
+++ b/src/main/java/com/cocotalk/chat/controller/ChatController.java
@@ -56,4 +56,12 @@ public class ChatController {
         simpMessagingTemplate.convertAndSend("/topic/" + roomId + "/message", messageWithRoomVo.getMessageVo());
         simpMessagingTemplate.convertAndSend("/topic/" + roomId + "/room", messageWithRoomVo.getRoomVo());
     }
+
+    @MessageMapping("/{roomId}/message/awake")
+    public void awake(@DestinationVariable ObjectId roomId,
+                      @Payload ChatMessageRequest awakeMessageRequest) {
+        MessageWithRoomVo<ChatMessageVo> messageWithRoomVo = roomService.saveAwakeMessage(roomId, awakeMessageRequest);
+        simpMessagingTemplate.convertAndSend("/topic/" + roomId + "/message", messageWithRoomVo.getMessageVo());
+        simpMessagingTemplate.convertAndSend("/topic/" + roomId + "/room", messageWithRoomVo.getRoomVo());
+    }
 }

--- a/src/main/java/com/cocotalk/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/cocotalk/chat/dto/request/ChatMessageRequest.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.bson.types.ObjectId;
 
-import java.time.LocalDateTime;
-
 @Getter
+@ToString
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/cocotalk/chat/dto/request/InviteMessageRequest.java
+++ b/src/main/java/com/cocotalk/chat/dto/request/InviteMessageRequest.java
@@ -3,11 +3,13 @@ package com.cocotalk.chat.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
 @Getter
+@ToString
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/cocotalk/chat/repository/CustomRoomRepository.java
+++ b/src/main/java/com/cocotalk/chat/repository/CustomRoomRepository.java
@@ -3,8 +3,9 @@ package com.cocotalk.chat.repository;
 import com.cocotalk.chat.domain.entity.room.Room;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomRoomRepository {
-    // Optional<Room> findPrivate(Long userId, Long friendId);
+    Optional<Room> findPrivate(Long userId, Long friendId);
     List<Room> findJoiningRoom(Long userId);
 }

--- a/src/main/java/com/cocotalk/chat/repository/CustomRoomRepositoryImpl.java
+++ b/src/main/java/com/cocotalk/chat/repository/CustomRoomRepositoryImpl.java
@@ -1,33 +1,32 @@
 package com.cocotalk.chat.repository;
 
 import com.cocotalk.chat.domain.entity.room.Room;
+import com.cocotalk.chat.domain.entity.room.RoomType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class CustomRoomRepositoryImpl implements CustomRoomRepository {
     private final MongoTemplate mongoTemplate;
 
-//    @Override
-//    public Optional<Room> findPrivate(Long userId, Long friendId) {
-//        Query query = new Query();
-//        query.addCriteria(Criteria.where("type").is(RoomType.PRIVATE.ordinal()));
-//        query.addCriteria(Criteria.where("members").elemMatch(Criteria.where("userId").in(userId))
-//                .andOperator(Criteria.where("members").elemMatch(Criteria.where("userId").in(friendId)))
-//                .andOperator(Criteria.where("type").is(RoomType.PRIVATE.ordinal())));
-//        return Optional.ofNullable(mongoTemplate.findOne(query, Room.class));
-//    }
+    @Override
+    public Optional<Room> findPrivate(Long userId, Long friendId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("type").is(RoomType.PRIVATE.ordinal()));
+        query.addCriteria(Criteria.where("members").elemMatch(Criteria.where("userId").is(userId))
+                .andOperator(Criteria.where("members").elemMatch(Criteria.where("userId").is(friendId))));
+        return Optional.ofNullable(mongoTemplate.findOne(query, Room.class));
+    }
 
     @Override
     public List<Room> findJoiningRoom(Long userId) {
         Query query = new Query();
-        query.addCriteria(Criteria.where("members")
-                .elemMatch(Criteria.where("userId").is(userId))
-                .elemMatch(Criteria.where("joining").is(true)));
+        query.addCriteria(Criteria.where("members").elemMatch(Criteria.where("userId").is(userId).and("joining").is(true)));
         return mongoTemplate.find(query, Room.class);
     }
 }

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -161,7 +161,7 @@ button.accent {
 }
 
 /*얘가 문제임*/
-#chat-page #messageForm #inviteForm {
+#chat-page #messageForm #inviteForm #awakeForm #leaveForm {
     padding: 20px;
 }
 
@@ -229,6 +229,11 @@ button.accent {
     width: calc(100% - 85px);
 }
 
+#awakeForm .input-group input {
+    float: left;
+    width: calc(100% - 85px);
+}
+
 #messageForm .input-group button {
     float: left;
     width: 80px;
@@ -237,6 +242,13 @@ button.accent {
 }
 
 #inviteForm .input-group button {
+    float: left;
+    width: 80px;
+    height: 38px;
+    margin-left: 5px;
+}
+
+#awakeForm .input-group button {
     float: left;
     width: 80px;
     height: 38px;
@@ -309,6 +321,14 @@ button.accent {
     }
 
     #inviteForm .input-group input {
+        width: calc(100% - 70px);
+    }
+
+    #awakeForm .input-group button {
+        width: 65px;
+    }
+
+    #awakeForm .input-group input {
         width: calc(100% - 70px);
     }
 

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -5,9 +5,11 @@ const chatPage = document.querySelector('#chat-page');
 const usernameForm = document.querySelector('#usernameForm');
 const messageForm = document.querySelector('#messageForm');
 const inviteForm = document.querySelector('#inviteForm');
-const inviteInput = document.querySelector('#inviteeId');
+const awakeForm = document.querySelector('#awakeForm');
 const leaveForm = document.querySelector('#leaveForm');
 const messageInput = document.querySelector('#message');
+const inviteInput = document.querySelector('#inviteeId');
+const awakeInput = document.querySelector('#awakeMessage');
 const messageArea = document.querySelector('#messageArea');
 const connectingElement = document.querySelector('.connecting');
 
@@ -154,7 +156,6 @@ function onConnectAndSend() {
             messageBundleId: nextMessageBundleId,
             type: 0,
             content: messageInput.value
-            // sentAt: getLocalDateTime()
         };
 
         chatRoomClient.send("/simple/chatroom/" + roomId + "/message/send", {}, JSON.stringify(chatMessage));
@@ -188,7 +189,6 @@ function sendMessage(event) {
             messageBundleId: nextMessageBundleId,
             type: 0,
             content: messageInput.value
-            // sentAt: getLocalDateTime()
         };
 
         chatRoomClient.send("/simple/chatroom/" + roomId + "/message/send", {}, JSON.stringify(chatMessage));
@@ -208,10 +208,26 @@ function invite (event) {
             messageBundleId: nextMessageBundleId,
             type: 3,
             content: userId + '가 입장했습니다.'
-            // sentAt: getLocalDateTime()
         }
 
         chatRoomClient.send("/simple/chatroom/" + roomId + "/message/invite", {}, JSON.stringify(inviteMessage));
+        inviteInput.value = '';
+    }
+    event.preventDefault();
+}
+
+function awake(event) {
+    const messageContent = awakeInput.value.trim();
+    if(messageContent && chatRoomClient) {
+        let awakeMessage = {
+            roomId: roomId,
+            userId: userId,
+            messageBundleId: nextMessageBundleId,
+            type: 5,
+            content: messageContent
+        }
+
+        chatRoomClient.send("/simple/chatroom/" + roomId + "/message/awake", {}, JSON.stringify(awakeMessage));
         inviteInput.value = '';
     }
     event.preventDefault();
@@ -334,3 +350,4 @@ function getLocalDateTime() {
 usernameForm.addEventListener('submit', enter, true)
 inviteForm.addEventListener('submit', invite, true)
 leaveForm.addEventListener('submit', leave, true)
+awakeForm.addEventListener('submit', awake, true)

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -44,7 +44,7 @@
             <form id="messageForm" name="messageForm" nameForm="messageForm">
                 <div class="form-group">
                     <div class="input-group clearfix">
-                        <input type="text" id="message" placeholder="Type a message..." autocomplete="off" class="form-control"/>
+                        <input type="text" id="message" placeholder="Type a message" autocomplete="off" class="form-control"/>
                         <button type="submit" class="primary">Send</button>
                     </div>
                 </div>
@@ -54,6 +54,14 @@
                     <div class="input-group clearfix">
                         <input type="text" id="inviteeId" placeholder="Type a inviteeId" autocomplete="off" class="form-control"/>
                         <button type="submit" class="primary invite">invite</button>
+                    </div>
+                </div>
+            </form>
+            <form id="awakeForm" name="awakeForm" nameForm="awakeForm">
+                <div class="form-group">
+                    <div class="input-group clearfix">
+                        <input type="text" id="awakeMessage" placeholder="Type a awake message" autocomplete="off" class="form-control"/>
+                        <button type="submit" class="primary awake">awake</button>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
## 관련 이슈 연결
- #6
- #10 

## 변경/추가 사항, 자세한 설명
- Awake(1:1 채팅방에서 상대방이 나갔을 때 isJoining = true로 만들어 채팅방 리스트에서 조회할 수 있게 함) 메시지 기능 추가
- GET chat/rooms/list 요청시 채팅방 리스트 조회 불가 문제 mongoTemplate 코드 수정으로 해결

## 그 외 전달 사항
- 1:1 채팅방 조회 mongoTemplate으로 수정
- 테스트 페이지에 Awake 메시지 form 추가