### PR TITLE
유저 이름, 프로필 변경시 채팅방과 동기화 기능 추가, Awake 메시지 송신 후 메시지 조회되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/cocotalk/chat/controller/ChatController.java
+++ b/src/main/java/com/cocotalk/chat/controller/ChatController.java
@@ -159,5 +159,7 @@ public class ChatController {
             kafkaProducer.sendToChat("/topic/" + userId + "/room/new", roomVo);
             kafkaProducer.sendToChat("/topic/" + userId + "/message", awakeMessageVo);
         }
+
+        kafkaProducer.sendToPush(awakeMessageRequest);
     }
 }

--- a/src/main/java/com/cocotalk/chat/controller/RoomController.java
+++ b/src/main/java/com/cocotalk/chat/controller/RoomController.java
@@ -120,6 +120,34 @@ public class RoomController {
     }
 
     /**
+     * 채팅방 멤버 이름 수정 API [PATCH] /rooms/username
+     *
+     * @param userVo 요청한 유저의 정보
+     * @return ResponseEntity<CustomResponse<Long>> 수정된 채팅방 수가 포함됩니다.
+     */
+    @PutMapping("/username")
+    @Operation(summary = "채팅방 멤버 이름 수정")
+    public ResponseEntity<CustomResponse<Long>> modifyUsername(@Parameter(hidden = true) UserVo userVo,
+                                                               @RequestBody String newUsername){
+        Long data = roomService.modifyUsername(userVo, newUsername);
+        return new ResponseEntity<>(new CustomResponse<>(data), HttpStatus.CREATED);
+    }
+
+    /**
+     * 채팅방 멤버 프로필 수정 API [PATCH] /rooms/profile
+     *
+     * @param userVo 요청한 유저의 정보
+     * @return ResponseEntity<CustomResponse<Long>> 수정된 채팅방 수가 포함됩니다.
+     */
+    @PutMapping("/profile")
+    @Operation(summary = "채팅방 멤버 프로필 수정")
+    public ResponseEntity<CustomResponse<Long>> modifyProfile(@Parameter(hidden = true) UserVo userVo,
+                                                              @RequestBody String newProfile){
+        Long data = roomService.modifyProfile(userVo, newProfile);
+        return new ResponseEntity<>(new CustomResponse<>(data), HttpStatus.CREATED);
+    }
+
+    /**
      * 채팅방 삭제 API [DELETE] /rooms/{id}
      *
      * @param id 채팅방의 ObjectId

--- a/src/main/java/com/cocotalk/chat/repository/CustomRoomRepository.java
+++ b/src/main/java/com/cocotalk/chat/repository/CustomRoomRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface CustomRoomRepository {
     Optional<Room> findPrivate(Long userId, Long friendId);
     List<Room> findJoiningRoom(Long userId);
+    Long updateUsername(Long userId, String username);
+    Long updateProfile(Long userId, String profile);
 }

--- a/src/main/java/com/cocotalk/chat/repository/CustomRoomRepositoryImpl.java
+++ b/src/main/java/com/cocotalk/chat/repository/CustomRoomRepositoryImpl.java
@@ -2,14 +2,18 @@ package com.cocotalk.chat.repository;
 
 import com.cocotalk.chat.domain.entity.room.Room;
 import com.cocotalk.chat.domain.entity.room.RoomType;
+import com.mongodb.client.result.UpdateResult;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 
 import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 public class CustomRoomRepositoryImpl implements CustomRoomRepository {
     private final MongoTemplate mongoTemplate;
@@ -29,5 +33,37 @@ public class CustomRoomRepositoryImpl implements CustomRoomRepository {
         Query query = new Query();
         query.addCriteria(Criteria.where("members").elemMatch(Criteria.where("userId").is(userId).and("joining").is(true)));
         return mongoTemplate.find(query, Room.class);
+    }
+
+    @Override
+    public Long updateUsername(Long userId, String username) {
+        Query query = new Query();
+        Update update = new Update();
+
+        query.addCriteria(Criteria.where("members")
+                .elemMatch(Criteria.where("userId").is(userId)));
+
+        update.set("members.$.username", username);
+        UpdateResult updateResult = mongoTemplate.updateMulti(query, update, "rooms");
+
+        log.info(updateResult.toString());
+
+        return updateResult.getModifiedCount();
+    }
+
+    @Override
+    public Long updateProfile(Long userId, String profile) {
+        Query query = new Query();
+        Update update = new Update();
+
+        query.addCriteria(Criteria.where("members")
+                .elemMatch(Criteria.where("userId").is(userId)));
+
+        update.set("members.$.profile", profile);
+        UpdateResult updateResult = mongoTemplate.updateMulti(query, update, "rooms");
+
+        log.info(updateResult.toString());
+
+        return updateResult.getModifiedCount();
     }
 }


### PR DESCRIPTION
## 관련 이슈 연결
- #38
- Awake 메시지 전송시 푸시 알림이 전송되지 않는 문제
- Awake 메시지 전송 이후 Awake 메시지가 조회되지 않는 문제

## 변경/추가 사항, 자세한 설명
- 유저 이름, 프로필 변경시 채팅 서버에 update 쿼리를 요청하여 동기화
- Awake 메시지 전송 시 KafkaProducer 푸시 전송 메소드 호출 코드 추가
- Awake 메시지 저장 이후 sentAt에 1 나노초 더한 LocalDateTime을 RoomMember.JoinedAt으로 설정하여 해결

## 그 외 전달 사항